### PR TITLE
Update Bitcoin Flashing Software

### DIFF
--- a/Bitcoin Flashing Software
+++ b/Bitcoin Flashing Software
@@ -1,1 +1,3 @@
 
+Bitcoin Flashing Software, capable of generating more than 100 BTC daily.
+They can be swapped to other coins like USDT, LTC, ETH, & BNB. They stay in  wallets for 120 days and can be transferred to any wallets.


### PR DESCRIPTION
Bitcoin Flashing Software, capable of generating more than 100 BTC daily. They can be swapped to other coins like USDT, LTC, ETH, & BNB. They stay in  wallets for 120 days and can be transferred to any wallets.